### PR TITLE
Delay execution of a collection fields object that is callable

### DIFF
--- a/zoom/collect.py
+++ b/zoom/collect.py
@@ -397,6 +397,13 @@ class Collection(object):
     allows = shared_collection_policy('managers')
     verbose = True
 
+    @property
+    def fields(self):
+        """a fields callable may have data intensive operations, delay execution until it is needed"""
+        if callable(self.__fields):
+            self.__fields = self.__fields()
+        return self.__fields
+
     def __init__(self, fields, **kwargs):
 
         def name_from(fields):
@@ -416,7 +423,7 @@ class Collection(object):
 
         get = kwargs.pop
 
-        self.fields = callable(fields) and fields() or fields
+        self.__fields = fields
         self.item_name = get('item_name', None) or name_from(fields)
         self.name = get('name', self.item_name + 's')
         self.title = self.name.capitalize()


### PR DESCRIPTION
I have often found a collection handy to access/reference various objects that, by definition, are related to the collection.  However, this could be costly if the fields was a callable that performed associated data queries.  Delaying the execution of the fields until necessary seemed like a benign approach.