### PR TITLE
Be more specific in group id lookup for a user

### DIFF
--- a/zoom/users.py
+++ b/zoom/users.py
@@ -99,6 +99,7 @@ class User(Record):
         self.is_authenticated = False
         self.__groups = None
         self.__user_groups = None
+        self.__user_group_ids = None
         self.__apps = None
 
     def allows(self, user, action):
@@ -252,12 +253,12 @@ class User(Record):
     @property
     def groups_ids(self):
         """Returns the IDs for the groups the user belongs to"""
-        groups = self.groups
-        if groups is None:
+        if self.__user_group_ids is None:
             # if we have groups then we have a store so avoid another check here
-            cmd = 'select id from groups where name in (%s)'% (', '.join(['%s'] * len(groups)))
-            return [i[0] for i in self.get('__store').db(cmd, *groups)]  # list of group id's
-        return []
+            groups = self.groups
+            cmd = 'select id from groups where name in (%s)' % (', '.join(['%s'] * len(groups)))
+            self.__user_group_ids = [i[0] for i in self.get('__store').db(cmd, *groups)]  # list of group id's
+        return self.__user_group_ids
 
     @property
     def apps(self):

--- a/zoom/users.py
+++ b/zoom/users.py
@@ -253,7 +253,7 @@ class User(Record):
     def groups_ids(self):
         """Returns the IDs for the groups the user belongs to"""
         groups = self.groups
-        if groups:
+        if groups is None:
             # if we have groups then we have a store so avoid another check here
             cmd = 'select id from groups where name in (%s)'% (', '.join(['%s'] * len(groups)))
             return [i[0] for i in self.get('__store').db(cmd, *groups)]  # list of group id's


### PR DESCRIPTION
Be more specific in group id lookup to eliminate duplicate queries when the results are empty