### PR TITLE
Pass kwargs in json dumps and support full coverage of zoom.json

### DIFF
--- a/tests/unittests/test_json.py
+++ b/tests/unittests/test_json.py
@@ -41,3 +41,14 @@ class TestConvert(unittest.TestCase):
         dj = dumps(d)
         d2 = loads(dj)
         self.assertEqual(d, d2)
+
+    def test_obj(self):
+        """test object literal decode - pass/fallthrough of object_hook of loads"""
+        d = [Decimal('22.32'), dict(status='this is a test')]
+        dj = dumps(d)
+        d2 = loads(dj)
+        self.assertListEqual(d, d2)
+
+    def test_error(self):
+        d = [Decimal('22.32'), self]
+        self.assertRaises(TypeError, dumps, d)

--- a/zoom/response.py
+++ b/zoom/response.py
@@ -214,7 +214,13 @@ class JSONResponse(TextResponse):
             ensure_ascii=False,
             **kwargs
     ):
-        content = dumps(content, indent, sort_keys, ensure_ascii, **kwargs)
+        content = dumps(
+            content,
+            indent=indent,
+            sort_keys=sort_keys,
+            ensure_ascii=ensure_ascii,
+            **kwargs
+        )
         TextResponse.__init__(self, content)
         self.headers['Content-type'] = 'application/json;charset=utf-8'
 


### PR DESCRIPTION
- Enhanced the JSON module tests to have full coverage
- Passed the JSON response arguments onto the underlying dumps as key-word arguments