### PR TITLE
Fix typo in readme and syntax error with database drop command

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,4 +156,4 @@ setup for sidetests (which uses webdriver, and various other libraries) you
 can skipthem by specifying only the other directories for tests.
 
     $ cd soure/libs/zoom
-    $ nosetests zoom tests/unitttests
+    $ nosetests zoom tests/unittests

--- a/tools/zoom/database.py
+++ b/tools/zoom/database.py
@@ -105,7 +105,7 @@ def create_database(args, name, parameters):
         db = zoom.database.database(**engine_params)
         if database_name in db.get_databases():
             if args.force:
-                db('drop database %s', database_name)
+                db('drop database %s' % database_name)
             else:
                 print('database {!r} exists'.format(database_name))
                 sys.exit(-1)


### PR DESCRIPTION
Fix syntax error with database drop command and fix typo in test command in Readme.